### PR TITLE
Potential fix for code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/final_project/router/auth_users.js
+++ b/final_project/router/auth_users.js
@@ -64,6 +64,10 @@ regd_users.put("/auth/review/:isbn", (req, res) => {
   //post review with the username (stored in the session) posted
     const username = req.session.authorization['username'];
     const isbn = req.params.isbn;
+    // Prevent prototype pollution via dangerous keys
+    if (isbn === '__proto__' || isbn === 'constructor' || isbn === 'prototype') {
+        return res.status(400).send("Invalid ISBN value.");
+    }
     //accept a review as a request query
     const book = books[isbn];
 
@@ -91,6 +95,10 @@ regd_users.put("/auth/review/:isbn", (req, res) => {
 //delete book review
 regd_users.delete("/auth/review/:isbn", (req, res) => {
     const isbn = req.params.isbn;
+    // Prevent prototype pollution via dangerous keys
+    if (isbn === '__proto__' || isbn === 'constructor' || isbn === 'prototype') {
+        return res.status(400).send("Invalid ISBN value.");
+    }
     const book = books[isbn];
 
     if(book) {


### PR DESCRIPTION
Potential fix for [https://github.com/nathandeflavis/expressBookReviews/security/code-scanning/9](https://github.com/nathandeflavis/expressBookReviews/security/code-scanning/9)

To fix this prototype pollution vulnerability, we need to prevent user-controlled input from being used as an object key if it could be a dangerous value like `__proto__`, `constructor`, or `prototype`. The best way to do this without changing existing functionality is to add a check that rejects any such dangerous keys before using them to access or assign properties on the `books` object. This check should be added at the start of the affected route handler(s), specifically before any use of `req.params.isbn` as an object key. If the key is dangerous, return an error response and do not proceed.

No new methods or imports are needed; just a simple check and early return in the relevant route(s).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
